### PR TITLE
feat: validation , confirmation and register urls APIs

### DIFF
--- a/app/api/confirmation/route.ts
+++ b/app/api/confirmation/route.ts
@@ -1,0 +1,6 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export const POST = async (req: NextRequest) => {
+  //When this API is hit it does nothing for now. The use case of this API is not currently yet defined but some facilities may register this URL.
+  return NextResponse.json({ message: "confirmed" }, { status: 200 });
+};

--- a/app/api/register-url/route.ts
+++ b/app/api/register-url/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from "next/server";
+import axios from "axios";
+import { BASE_URL } from "@/config/env";
+import { getHealthFacilityMpesaConfig } from "@/config/mpesa-config";
+import { generateAccessToken } from "@/daraja/access-token";
+import { RegisterUrlResponse } from "daraja-kit";
+
+// This is a one-time API call that registers your validation and confirmation URLs
+export const POST = async (req: NextRequest) => {
+  const requestBody = (await req.json()) as { mfl: string };
+
+  const facilityMpesaConfig = getHealthFacilityMpesaConfig(requestBody.mfl);
+
+  if (!facilityMpesaConfig) {
+    return NextResponse.json(
+      { message: "Health Facility Mpesa Data not configured." },
+      { status: 403 }
+    );
+  }
+
+  const accessTokenResponse = await generateAccessToken(facilityMpesaConfig);
+
+  const res: RegisterUrlResponse = await axios.post(
+    `${BASE_URL}/mpesa/c2b/v1/registerurl`,
+    {
+      ShortCode: facilityMpesaConfig.MPESA_BUSINESS_SHORT_CODE,
+      ResponseType: "Completed",
+      ConfirmationURL: `${BASE_URL}/api/confirmation`,
+      ValidationURL: `${BASE_URL}/api/validation`,
+    },
+    {
+      headers: {
+        Authorization: `Bearer ${accessTokenResponse.access_token}`,
+      },
+    }
+  );
+
+  if (res.ResponseCode === "0") {
+    return NextResponse.json({ message: "success" }, { status: 200 });
+  } else {
+    return NextResponse.json(
+      { message: "an error might have occurred" },
+      { status: 500 }
+    );
+  }
+};

--- a/app/api/validation/route.ts
+++ b/app/api/validation/route.ts
@@ -1,0 +1,9 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export const POST = async (req: NextRequest) => {
+  //When this API is hit it automatically completes the transaction.
+  return NextResponse.json({
+    ResultCode: "0",
+    ResultDesc: "Validation request received successfully",
+  });
+};


### PR DESCRIPTION
I have created three APIs.

1. **Validation URL** -> This is for request validation. The necessity of this API arose since safaricom tried to hit a non-existent API. In that case i created one to just complete the transaction. As more requirements arise we might have to include more logic in this API.
2. **Confirmation URL** -> Same thing as Validation URL. It does nothing but since it is required it just responds back to safaricom with a success message.
3. **Register URLs AP**I -> This URL could be used to register ```confirmation``` and ```validation``` urls. The reason i created this is because this way i can handle thee request body that is used to register the URLs and thereby make them our aggregators URLs which are guaranteed to be online and alive. Its a post request that expects an object with an ```mfl``` key inside it.

Thats all this PR does.