### PR TITLE
refactor: migrated to mysql

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ next-env.d.ts
 mpesa-config.json
 mpesa-config-prod.json
 mpesa-config-dev.json
+
+# drizzle
+drizzle

--- a/app/api/mpesa/stk-push/route.ts
+++ b/app/api/mpesa/stk-push/route.ts
@@ -59,20 +59,17 @@ export const POST = async (request: NextRequest) => {
       healthFacilityMpesaConfig
     );
 
-    const dbRes = await db
-      .insert(payments)
-      .values({
-        mfl,
-        billId,
-        status: "INITIATED",
-        amount: requestBody.amount,
-        phoneNumber: requestBody.phoneNumber,
-        merchantReqId: stkPushRes.MerchantRequestID,
-      })
-      .returning({ requestId: payments.id });
+    const dbRes = await db.insert(payments).values({
+      mfl,
+      billId,
+      status: "INITIATED",
+      amount: requestBody.amount,
+      phoneNumber: requestBody.phoneNumber,
+      merchantReqId: stkPushRes.MerchantRequestID,
+    });
 
     const response = NextResponse.json(
-      { requestId: dbRes.at(0)?.requestId },
+      { requestId: dbRes[0].insertId },
       {
         status: 200,
       }

--- a/app/db/drizzle-client.ts
+++ b/app/db/drizzle-client.ts
@@ -1,9 +1,19 @@
-import { drizzle } from "drizzle-orm/libsql";
-import { createClient } from "@libsql/client";
+import {
+  DATABASE_HOST,
+  DATABASE_NAME,
+  DATABASE_PASSWORD,
+  DATABASE_USER,
+  DB_URL,
+} from "@/config/env";
+import { drizzle } from "drizzle-orm/mysql2";
+import mysql from "mysql2/promise";
 
-const client = createClient({
-  url: process.env.DATABASE_URL!,
-  authToken: process.env.DATABASE_AUTH_TOKEN,
+const connection = await mysql.createConnection({
+  host: DATABASE_HOST,
+  user: DATABASE_USER,
+  database: DATABASE_NAME,
+  password: DATABASE_PASSWORD,
+  uri: DB_URL,
 });
 
-export const db = drizzle(client);
+export const db = drizzle(connection);

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -1,8 +1,16 @@
 import { sql } from "drizzle-orm";
-import { sqliteTable, integer, text } from "drizzle-orm/sqlite-core";
+import {
+  int,
+  text,
+  mysqlSchema,
+  mysqlTable,
+  timestamp,
+} from "drizzle-orm/mysql-core";
 
-export const payments = sqliteTable("payments", {
-  id: integer("id").notNull().primaryKey(),
+export const schema = mysqlSchema("payments_schema");
+
+export const payments = mysqlTable("payments", {
+  id: int("id").primaryKey().autoincrement(),
   mfl: text("mfl").notNull(),
   billId: text("bill_id").notNull(),
   amount: text("amount").notNull(),
@@ -12,10 +20,6 @@ export const payments = sqliteTable("payments", {
   }).notNull(),
   merchantReqId: text("merchant_req_id"),
   receiptNumber: text("receipt_number"),
-  createdAt: text("created_at")
-    .default(sql`CURRENT_TIMESTAMP`)
-    .notNull(),
-  updatedAt: text("updated_at")
-    .default(sql`CURRENT_TIMESTAMP`)
-    .notNull(),
+  createdAt: timestamp("created_at").notNull().defaultNow(),
+  updatedAt: timestamp("updated_at").notNull().defaultNow(),
 });

--- a/config/env.ts
+++ b/config/env.ts
@@ -18,6 +18,31 @@ export const MPESA_APP_BASE_URL = assertValue(
   "Missing environment variable: MPESA_APP_BASE_URL"
 );
 
+export const DATABASE_NAME = assertValue(
+  process.env.DATABASE_NAME,
+  "Missing environment variable: DATABASE_NAME"
+);
+
+export const DATABASE_USER = assertValue(
+  process.env.DATABASE_USER,
+  "Missing environment variable: DATABASE_USER"
+);
+
+export const DATABASE_PASSWORD = assertValue(
+  process.env.DATABASE_PASSWORD,
+  "Missing environment variable: DATABASE_PASSWORD"
+);
+
+export const DATABASE_HOST = assertValue(
+  process.env.DATABASE_HOST,
+  "Missing environment variable: DATABASE_HOST"
+);
+
+export const DB_URL = assertValue(
+  process.env.DB_URL,
+  "Missing environment variable: DB_URL"
+);
+
 export function assertValue<T>(v: T | undefined, errorMessage: string): T {
   if (v === undefined) {
     throw new Error(errorMessage);

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,17 +1,27 @@
 import { defineConfig } from "drizzle-kit";
 
 import dotenv from "dotenv";
+import {
+  DATABASE_HOST,
+  DATABASE_NAME,
+  DATABASE_PASSWORD,
+  DATABASE_USER,
+  DB_URL,
+} from "./config/env";
 
 dotenv.config({
-  path: ".env.local",
+  path: ".env",
 });
 
 export default defineConfig({
   schema: "./app/db/schema.ts",
-  dialect: "sqlite",
-  driver: "turso",
+  dialect: "mysql",
+  out: "./drizzle",
   dbCredentials: {
-    url: process.env.DATABASE_URL!,
-    authToken: process.env.DATABASE_AUTH_TOKEN,
+    url: DB_URL,
+    database: DATABASE_NAME,
+    host: DATABASE_HOST,
+    password: DATABASE_PASSWORD,
+    user: DATABASE_USER,
   },
 });

--- a/env.example
+++ b/env.example
@@ -5,5 +5,8 @@ MPESA_APP_BASE_URL=
 APP_BASE_URL=
 
 # DATABASE
-DATABASE_URL=
-DATABASE_AUTH_TOKEN=
+DATABASE_NAME=kenyaemr_payments # the name of the database
+DATABASE_USER=root # the username of the db
+DATABASE_PASSWORD=admin # the password of the db
+DATABASE_HOST=localhost # the database host
+DB_URL="mysql:root@admin:3306/kenyaemr_payments"# the database url

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,11 @@
       "name": "payments-kenyaemr",
       "version": "0.1.0",
       "dependencies": {
-        "@libsql/client": "^0.6.2",
+        "@libsql/client": "^0.7.0",
         "daraja-kit": "^1.0.3",
         "dotenv": "^16.4.5",
-        "drizzle-orm": "^0.31.2",
-        "mysql2": "^3.10.1",
+        "drizzle-orm": "^0.31.4",
+        "mysql2": "^3.10.2",
         "next": "14.2.4",
         "react": "^18",
         "react-dom": "^18"
@@ -1140,22 +1140,21 @@
       }
     },
     "node_modules/@libsql/client": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@libsql/client/-/client-0.6.2.tgz",
-      "integrity": "sha512-xRNfRLv/dOCbV4qd+M0baQwGmvuZpMd2wG2UAPs8XmcdaPvu5ErkcaeITkxlm3hDEJVabQM1cFhMBxsugWW9fQ==",
-      "license": "MIT",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@libsql/client/-/client-0.7.0.tgz",
+      "integrity": "sha512-1aLDtWzsErr68GZ640TVyOLkL/+lB2YK8cYvJIfiI7Mt+DEPB22Jkoz2QfBDg5PVGX/efeRHog2j/oVbUhxO8Q==",
       "dependencies": {
-        "@libsql/core": "^0.6.2",
+        "@libsql/core": "^0.7.0",
         "@libsql/hrana-client": "^0.6.0",
         "js-base64": "^3.7.5",
-        "libsql": "^0.3.10"
+        "libsql": "^0.3.10",
+        "promise-limit": "^2.7.0"
       }
     },
     "node_modules/@libsql/core": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@libsql/core/-/core-0.6.2.tgz",
-      "integrity": "sha512-c2P4M+4u/4b2L02A0KjggO3UW51rGkhxr/7fzJO0fEAqsqrWGxuNj2YtRkina/oxfYvAof6xjp8RucNoIV/Odw==",
-      "license": "MIT",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@libsql/core/-/core-0.7.0.tgz",
+      "integrity": "sha512-hCYfXa0S4t9CJtxZIWacboylrcx94ZQO0dEngH4f0f/LHg6ymHSZiubbojAwD7tNy94ahICoGPjEi6aEIyhlcQ==",
       "dependencies": {
         "js-base64": "^3.7.5"
       }
@@ -1167,7 +1166,6 @@
       "cpu": [
         "arm64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -1180,7 +1178,6 @@
       "cpu": [
         "x64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -1190,7 +1187,6 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/@libsql/hrana-client/-/hrana-client-0.6.2.tgz",
       "integrity": "sha512-MWxgD7mXLNf9FXXiM0bc90wCjZSpErWKr5mGza7ERy2FJNNMXd7JIOv+DepBA1FQTIfI8TFO4/QDYgaQC0goNw==",
-      "license": "MIT",
       "dependencies": {
         "@libsql/isomorphic-fetch": "^0.2.1",
         "@libsql/isomorphic-ws": "^0.1.5",
@@ -1201,14 +1197,12 @@
     "node_modules/@libsql/isomorphic-fetch": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@libsql/isomorphic-fetch/-/isomorphic-fetch-0.2.1.tgz",
-      "integrity": "sha512-Sv07QP1Aw8A5OOrmKgRUBKe2fFhF2hpGJhtHe3d1aRnTESZCGkn//0zDycMKTGamVWb3oLYRroOsCV8Ukes9GA==",
-      "license": "MIT"
+      "integrity": "sha512-Sv07QP1Aw8A5OOrmKgRUBKe2fFhF2hpGJhtHe3d1aRnTESZCGkn//0zDycMKTGamVWb3oLYRroOsCV8Ukes9GA=="
     },
     "node_modules/@libsql/isomorphic-ws": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/@libsql/isomorphic-ws/-/isomorphic-ws-0.1.5.tgz",
       "integrity": "sha512-DtLWIH29onUYR00i0GlQ3UdcTRC6EP4u9w/h9LxpUZJWRMARk6dQwZ6Jkd+QdwVpuAOrdxt18v0K2uIYR3fwFg==",
-      "license": "MIT",
       "dependencies": {
         "@types/ws": "^8.5.4",
         "ws": "^8.13.0"
@@ -1221,7 +1215,6 @@
       "cpu": [
         "arm64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1234,7 +1227,6 @@
       "cpu": [
         "arm64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1247,7 +1239,6 @@
       "cpu": [
         "x64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1260,7 +1251,6 @@
       "cpu": [
         "x64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1273,7 +1263,6 @@
       "cpu": [
         "x64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1282,8 +1271,7 @@
     "node_modules/@neon-rs/load": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/@neon-rs/load/-/load-0.0.4.tgz",
-      "integrity": "sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==",
-      "license": "MIT"
+      "integrity": "sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw=="
     },
     "node_modules/@next/env": {
       "version": "14.2.4",
@@ -1571,7 +1559,6 @@
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
       "integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
-      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -2373,7 +2360,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
@@ -2525,7 +2511,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
       "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
       }
@@ -2583,11 +2568,10 @@
       }
     },
     "node_modules/drizzle-kit": {
-      "version": "0.22.7",
-      "resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.22.7.tgz",
-      "integrity": "sha512-9THPCb2l1GPt7wxhws9LvTR0YG565ZlVgTuqGMwjs590Kch1pXu4GyjEArVijSF5m0OBj3qgdeKmuJXhKXgWFw==",
+      "version": "0.22.8",
+      "resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.22.8.tgz",
+      "integrity": "sha512-VjI4wsJjk3hSqHSa3TwBf+uvH6M6pRHyxyoVbt935GUzP9tUR/BRZ+MhEJNgryqbzN2Za1KP0eJMTgKEPsalYQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@esbuild-kit/esm-loader": "^2.5.5",
         "esbuild": "^0.19.7",
@@ -2598,10 +2582,9 @@
       }
     },
     "node_modules/drizzle-orm": {
-      "version": "0.31.2",
-      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.31.2.tgz",
-      "integrity": "sha512-QnenevbnnAzmbNzQwbhklvIYrDE8YER8K7kSrAWQSV1YvFCdSQPzj+jzqRdTSsV2cDqSpQ0NXGyL1G9I43LDLg==",
-      "license": "Apache-2.0",
+      "version": "0.31.4",
+      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.31.4.tgz",
+      "integrity": "sha512-VGD9SH9aStF2z4QOTnVlVX/WghV/EnuEzTmsH3fSVp2E4fFgc8jl3viQrS/XUJx1ekW4rVVLJMH42SfGQdjX3Q==",
       "peerDependencies": {
         "@aws-sdk/client-rds-data": ">=3",
         "@cloudflare/workers-types": ">=3",
@@ -2611,6 +2594,7 @@
         "@op-engineering/op-sqlite": ">=2",
         "@opentelemetry/api": "^1.4.1",
         "@planetscale/database": ">=1",
+        "@prisma/client": "*",
         "@tidbcloud/serverless": "*",
         "@types/better-sqlite3": "*",
         "@types/pg": "*",
@@ -2653,6 +2637,9 @@
           "optional": true
         },
         "@planetscale/database": {
+          "optional": true
+        },
+        "@prisma/client": {
           "optional": true
         },
         "@tidbcloud/serverless": {
@@ -2698,6 +2685,9 @@
           "optional": true
         },
         "postgres": {
+          "optional": true
+        },
+        "prisma": {
           "optional": true
         },
         "react": {
@@ -3481,7 +3471,6 @@
           "url": "https://paypal.me/jimmywarting"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "node-domexception": "^1.0.0",
         "web-streams-polyfill": "^3.0.3"
@@ -3620,7 +3609,6 @@
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "license": "MIT",
       "dependencies": {
         "fetch-blob": "^3.1.2"
       },
@@ -4523,8 +4511,7 @@
     "node_modules/js-base64": {
       "version": "3.7.7",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
-      "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==",
-      "license": "BSD-3-Clause"
+      "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -4648,7 +4635,6 @@
         "arm64",
         "wasm32"
       ],
-      "license": "MIT",
       "os": [
         "darwin",
         "linux",
@@ -4829,10 +4815,9 @@
       "license": "MIT"
     },
     "node_modules/mysql2": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.10.1.tgz",
-      "integrity": "sha512-6zo1T3GILsXMCex3YEu7hCz2OXLUarxFsxvFcUHWMpkPtmZLeTTWgRdc1gWyNJiYt6AxITmIf9bZDRy/jAfWew==",
-      "license": "MIT",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.10.2.tgz",
+      "integrity": "sha512-KCXPEvAkO0RcHPr362O5N8tFY2fXvbjfkPvRY/wGumh4EOemo9Hm5FjQZqv/pCmrnuxGu5OxnSENG0gTXqKMgQ==",
       "dependencies": {
         "denque": "^2.1.0",
         "generate-function": "^2.3.1",
@@ -5006,7 +4991,6 @@
           "url": "https://paypal.me/jimmywarting"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=10.5.0"
       }
@@ -5015,7 +4999,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
       "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "license": "MIT",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -5534,6 +5517,11 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/promise-limit": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/promise-limit/-/promise-limit-2.7.0.tgz",
+      "integrity": "sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw=="
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -6586,7 +6574,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
@@ -6809,10 +6796,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-      "license": "MIT",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -6,14 +6,17 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "studio": "drizzle-kit studio",
+    "generate": "drizzle-kit generate",
+    "migrate": "drizzle-kit migrate"
   },
   "dependencies": {
-    "@libsql/client": "^0.6.2",
+    "@libsql/client": "^0.7.0",
     "daraja-kit": "^1.0.3",
     "dotenv": "^16.4.5",
-    "drizzle-orm": "^0.31.2",
-    "mysql2": "^3.10.1",
+    "drizzle-orm": "^0.31.4",
+    "mysql2": "^3.10.2",
     "next": "14.2.4",
     "react": "^18",
     "react-dom": "^18"


### PR DESCRIPTION
This PR migrates the app from using sqlite hosted on [turso](https://turso.tech/) to a mysql instance hosted wherever we need it. @Murithijoshua please make note of this change as it is a major change.

**Here is how to upgrade**
Everything remains the same except the env file. Please refer to the .env.example in the changed files tab of this PR. Here is the gist.

```
# APP ENVs
ENVIRONMENT=
MPESA_TRANSACTION_TYPE=
MPESA_APP_BASE_URL=
APP_BASE_URL=

# DATABASE
DATABASE_NAME=kenyaemr_payments # the name of the database
DATABASE_USER=root # the username of the db
DATABASE_PASSWORD=admin # the password of the db
DATABASE_HOST=localhost # the database host
DB_URL="mysql:root@admin:3306/kenyaemr_payments"# the database url

```
Similarly if you want to run the app locally just update the environment vars and make them point to the correct db.

However you must create the db and the ```payments``` table by running ```npm run generate``` which will generate the migration files and ```npm run migrate``` which will apply the migration on the target mysql instance.

This change was necessary as where i had hosted the db before was not where you guys host yours. This PR thereby fixes this issue.

Please feel free to contact in case of anything.