### PR TITLE
refactor: correct data type on confirmation and validation

### DIFF
--- a/app/api/confirmation/route.ts
+++ b/app/api/confirmation/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 
 export const POST = async (req: NextRequest) => {
-  //When this API is hit it does nothing for now. The use case of this API is not currently yet defined but some facilities may register this URL.
-  return NextResponse.json({ message: "confirmed" }, { status: 200 });
+  // When this API is hit it does nothing for now.
+  // The use case of this API is not currently yet defined but some facilities may register this URL.
+  return NextResponse.json({
+    ResultCode: 0,
+    ResultDesc: "Success",
+  });
 };

--- a/app/api/register-url/route.ts
+++ b/app/api/register-url/route.ts
@@ -23,7 +23,7 @@ export const POST = async (req: NextRequest) => {
   const res: RegisterUrlResponse = await axios.post(
     `${BASE_URL}/mpesa/c2b/v1/registerurl`,
     {
-      ShortCode: facilityMpesaConfig.MPESA_BUSINESS_SHORT_CODE,
+      ShortCode: parseInt(facilityMpesaConfig.MPESA_BUSINESS_SHORT_CODE),
       ResponseType: "Completed",
       ConfirmationURL: `${BASE_URL}/api/confirmation`,
       ValidationURL: `${BASE_URL}/api/validation`,

--- a/app/api/validation/route.ts
+++ b/app/api/validation/route.ts
@@ -4,6 +4,6 @@ export const POST = async (req: NextRequest) => {
   //When this API is hit it automatically completes the transaction.
   return NextResponse.json({
     ResultCode: "0",
-    ResultDesc: "Validation request received successfully",
+    ResultDesc: "Accepted",
   });
 };


### PR DESCRIPTION
This PR fixes the endpoints safaricom hits with correct responses to avoid failing requests as we wait for @Injiri to configure the validtion and confirmation URLs