### PR TITLE
refactor: allow for transaction type and partyB configuration.

### DIFF
--- a/config/env.ts
+++ b/config/env.ts
@@ -8,11 +8,6 @@ export const BASE_URL =
     ? "https://api.safaricom.co.ke"
     : "https://sandbox.safaricom.co.ke";
 
-export const MPESA_TRANSACTION_TYPE = assertValue(
-  process.env.MPESA_TRANSACTION_TYPE,
-  "Missing environment variable: MPESA_TRANSACTION_TYPE"
-);
-
 export const MPESA_APP_BASE_URL = assertValue(
   process.env.MPESA_APP_BASE_URL,
   "Missing environment variable: MPESA_APP_BASE_URL"

--- a/config/mpesa-config.ts
+++ b/config/mpesa-config.ts
@@ -6,11 +6,13 @@ export type MPESA_CONFIG = {
   MPESA_CONSUMER_KEY: string;
   MPESA_CONSUMER_SECRET: string;
   MPESA_API_PASS_KEY: string;
+  MPESA_TILL_OR_PAYBILL_NO: string;
+  MPESA_TRANSACTION_TYPE: "BUY-GOODS" | "PAYBILL";
 };
 
 // HASHMAP
 const mpesaConfigMap: { [key: string]: MPESA_CONFIG } = assertValue(
-  configData,
+  configData as { [key: string]: MPESA_CONFIG },
   "MISSING MPESA CONFIGURATION FILE"
 );
 

--- a/daraja/stk-push.ts
+++ b/daraja/stk-push.ts
@@ -34,7 +34,11 @@ export const stkPushRequest = async (
   }: STKPushRequestParam,
   mpesaConfig: MPESA_CONFIG
 ) => {
-  const { MPESA_BUSINESS_SHORT_CODE } = mpesaConfig;
+  const {
+    MPESA_BUSINESS_SHORT_CODE,
+    MPESA_TILL_OR_PAYBILL_NO,
+    MPESA_TRANSACTION_TYPE,
+  } = mpesaConfig;
 
   try {
     const timestamp = generateTimestamp();
@@ -43,7 +47,7 @@ export const stkPushRequest = async (
 
     const stkPushBody: STKPushBody = {
       BusinessShortCode: MPESA_BUSINESS_SHORT_CODE,
-      PartyB: MPESA_BUSINESS_SHORT_CODE,
+      PartyB: MPESA_TILL_OR_PAYBILL_NO,
       Timestamp: timestamp,
       Password: password,
       PartyA: phoneNumber,
@@ -51,10 +55,14 @@ export const stkPushRequest = async (
       Amount: ENVIRONMENT === "production" ? amount : "1",
       CallBackURL: callbackURL,
       TransactionDesc: transactionDesc,
-      TransactionType: process.env
-        .MPESA_TRANSACTION_TYPE as unknown as TransactionType,
+      TransactionType:
+        MPESA_TRANSACTION_TYPE === "BUY-GOODS"
+          ? "CustomerBuyGoodsOnline"
+          : "CustomerPayBillOnline",
       AccountReference: accountReference,
     };
+
+    console.log("stk-push-body", stkPushBody);
 
     const accessTokenResponse = await generateAccessToken(mpesaConfig);
 


### PR DESCRIPTION
This PR allows for configuration of 

- `Transaction Type` : Previously we assumed that the health facilities will be using `Pay Bill` and didn't account for those that may be using `till numbers`. For flexibility we allow the users of the system configure what they have.
- `PartyB`: Same thing. Sometimes the till number does not necessary be the same as the business short code (although they could be the same, an approach I had previously assumed to be correct) from the daraja docs :

> PartyB- The organization that receives the funds. The parameter expected is a 5 to 6-digit as defined in the Shortcode description above. This can be the same as the BusinessShortCode value above.

This now fixes the issues we were facing with failed transactions. Thanks @Injiri for your help and support. 