### PR TITLE
(feat) : Add dedicated API for EMR bill reconciliation with M-Pesa payments

### DIFF
--- a/app/api/mpesa/check-payment-state-by-bill-id/route.ts
+++ b/app/api/mpesa/check-payment-state-by-bill-id/route.ts
@@ -1,0 +1,72 @@
+import { db } from "@/app/db/drizzle-client";
+import { payments } from "@/app/db/schema";
+import { corsOptions } from "@/utils/cors";
+import { eq } from "drizzle-orm";
+import { NextRequest, NextResponse } from "next/server";
+
+export const POST = async (req: NextRequest) => {
+  const body: { billId: string } = await req.json();
+
+  try {
+    const paymentRequests = await db
+      .select()
+      .from(payments)
+      .where(eq(payments.billId, body.billId));
+
+    let response: NextResponse<
+      Array<{
+        requestStatus: string;
+        referenceNumber: string | null;
+        amount: string;
+      }>
+    >;
+
+    response = NextResponse.json(
+      paymentRequests.map((req) => {
+        return {
+          requestStatus: req.status,
+          referenceNumber: req.receiptNumber,
+          amount: req.amount,
+        };
+      }),
+      {
+        status: 200,
+      }
+    );
+
+    const origin = req.headers.get("origin") ?? "";
+    // const isAllowedOrigin = allowedOrigins.includes(origin);
+    const isAllowedOrigin = true;
+
+    if (isAllowedOrigin) {
+      response.headers.set("Access-Control-Allow-Origin", origin);
+    }
+
+    Object.entries(corsOptions).forEach(([key, value]) => {
+      response.headers.set(key, value);
+    });
+
+    return response;
+  } catch (error) {
+    return NextResponse.json(
+      {
+        message: "An error occurred",
+      },
+      {
+        status: 500,
+      }
+    );
+  }
+};
+
+export const OPTIONS = async (request: NextRequest) => {
+  const origin = request.headers.get("origin") ?? "";
+  // const isAllowedOrigin = allowedOrigins.includes(origin);
+  const isAllowedOrigin = true;
+
+  const preflightHeaders = {
+    ...(isAllowedOrigin && { "Access-Control-Allow-Origin": origin }),
+    ...corsOptions,
+  };
+  return NextResponse.json({}, { headers: preflightHeaders });
+};


### PR DESCRIPTION
This PR adds a new API to allow the EMR to reconcile its bills with the paid m-pesa requests silently. 
@ojwanganto it was technically difficult to reuse the stk-push one because a bill could have multiple m-pesa payment requests. There is a possibility to return a certain payment request as completed because a preceding one was completed. To avoid this I opted to create a new one that will allow the EMR to silently update its bills and treat any new request as truly new.